### PR TITLE
fix: declare main script entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ Repository = "https://github.com/lucabello/hledger-tui"
 Issues = "https://github.com/lucabello/hledger-tui/issues"
 Changelog = "https://github.com/lucabello/hledger-tui/releases"
 
+[project.scripts]
+hledger-tui = "hledger_tui.__main__:cli"
 
 # Building and publishing
 [build-system]


### PR DESCRIPTION
Using `uv build` directly will autodetect this, but other ways of invoking a build including `python -m build` used by many distros will not auto detect the script even when the uv_build backed is used.
