### PR TITLE
feat: add windows support by switching sh to subprocess

### DIFF
--- a/justfile
+++ b/justfile
@@ -59,7 +59,6 @@ coverage:
 venv:
     @echo "Activating virtual environment..."
     @uv sync --all-groups
-    @#!/usr/bin/env bash
     @. .venv/Scripts/activate 2>/dev/null || . .venv/bin/activate; exec "$SHELL" -i
 
 # ============================================================================

--- a/justfile
+++ b/justfile
@@ -59,7 +59,8 @@ coverage:
 venv:
     @echo "Activating virtual environment..."
     @uv sync --all-groups
-    @. .venv/bin/activate; exec "$SHELL" -i
+    @#!/usr/bin/env bash
+    @. .venv/Scripts/activate 2>/dev/null || . .venv/bin/activate; exec "$SHELL" -i
 
 # ============================================================================
 # Build & Package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
   "textual",
   "textual-dev",
   "textual-plotext",
-  "sh",
   "typer",
   "dataconfy",
 ]

--- a/src/hledger_tui/core/service.py
+++ b/src/hledger_tui/core/service.py
@@ -8,7 +8,6 @@ from io import StringIO
 from typing import ClassVar, Final, List, Optional
 
 from hledger_tui.config import config
-from hledger_tui.core.subprocess_executor import SubprocessExecutor, HLedgerCommand
 from hledger_tui.core.models import (
     AccountHistoricalBalance,
     CategoricalBalance,
@@ -16,6 +15,7 @@ from hledger_tui.core.models import (
     Transaction,
 )
 from hledger_tui.core.period import HLedgerPeriod
+from hledger_tui.core.subprocess_executor import HLedgerCommand, SubprocessExecutor
 
 
 class HLedgerBackend(ABC):

--- a/src/hledger_tui/core/service.py
+++ b/src/hledger_tui/core/service.py
@@ -7,9 +7,8 @@ from datetime import datetime, timedelta
 from io import StringIO
 from typing import ClassVar, Final, List, Optional
 
-import sh
-
 from hledger_tui.config import config
+from hledger_tui.core.subprocess_executor import SubprocessExecutor, HLedgerCommand
 from hledger_tui.core.models import (
     AccountHistoricalBalance,
     CategoricalBalance,
@@ -62,28 +61,40 @@ class HLedgerBackend(ABC):
 
 
 class ShellHLedgerBackend(HLedgerBackend):
-    """HLedger backend implementation using shell command execution via sh library."""
+    """HLedger backend implementation using subprocess for cross-platform support."""
+
+    def __init__(self):
+        """Initialize the backend with a subprocess executor."""
+        self.executor = SubprocessExecutor()
+        self.hledger = HLedgerCommand(self.executor)
 
     def balance(self, queries: List[str], **kwargs) -> str:
-        return sh.hledger.balance(queries, **kwargs)  # pyright: ignore
+        """Execute 'hledger balance' and return raw output."""
+        return self.hledger.balance(queries, **kwargs)
 
     def register(self, queries: List[str], **kwargs) -> str:
-        return sh.hledger.register(queries, **kwargs)  # pyright: ignore
+        """Execute 'hledger register' and return raw output."""
+        return self.hledger.register(queries, **kwargs)
 
     def stats(self) -> str:
-        return sh.hledger.stats(_tty_out=False).strip()  # pyright: ignore
+        """Execute 'hledger stats' and return raw output."""
+        return self.hledger.stats(_tty_out=False).strip()
 
     def files(self) -> str:
-        return sh.hledger.files(_tty_out=False).strip()  # pyright: ignore
+        """Execute 'hledger files' and return raw output."""
+        return self.hledger.files(_tty_out=False).strip()
 
     def accounts(self, queries: List[str]) -> str:
-        return sh.hledger.accounts(queries)  # pyright: ignore
+        """Execute 'hledger accounts' and return raw output."""
+        return self.hledger.accounts(queries)
 
     def tags(self, **kwargs) -> str:
-        return sh.hledger.tags(**kwargs)  # pyright: ignore
+        """Execute 'hledger tags' and return raw output."""
+        return self.hledger.tags(**kwargs)
 
     def commodities(self, **kwargs) -> str:
-        return sh.hledger.commodities(_tty_out=False, **kwargs).strip()  # pyright: ignore
+        """Execute 'hledger commodities' and return raw output."""
+        return self.hledger.commodities(_tty_out=False, **kwargs).strip()
 
 
 class HLedger:

--- a/src/hledger_tui/core/subprocess_executor.py
+++ b/src/hledger_tui/core/subprocess_executor.py
@@ -187,7 +187,8 @@ class SubprocessExecutor:
             Escaped argument string
         """
         if '"' in arg or " " in arg:
-            return f'"{arg.replace('"', '\\"')}"'
+            escaped = arg.replace('"', '\\"')
+            return f'"{escaped}"'
         return arg
 
     def __call__(

--- a/src/hledger_tui/core/subprocess_executor.py
+++ b/src/hledger_tui/core/subprocess_executor.py
@@ -1,0 +1,241 @@
+"""Cross-platform subprocess executor for hledger-tui.
+
+Provides a sh-like API using subprocess module for Windows compatibility.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+
+class CommandError(Exception):
+    """Exception raised when a command fails."""
+
+    def __init__(self, command: List[str], returncode: int, stderr: Optional[str] = None):
+        self.command = command
+        self.returncode = returncode
+        self.stderr = stderr
+        message = f"Command '{' '.join(command)}' failed with exit code {returncode}"
+        if stderr:
+            message += f"\nStderr: {stderr}"
+        super().__init__(message)
+
+
+class SubprocessExecutor:
+    """Cross-platform command executor using subprocess.
+
+    Provides a convenient API similar to the sh library, but with better
+    Windows support using the standard subprocess module.
+    """
+
+    def __init__(self, env: Optional[Dict[str, str]] = None):
+        """Initialize the executor.
+
+        Args:
+            env: Optional environment variables to pass to subprocess
+        """
+        self.env = env or {}
+
+    def _kwargs_to_args(self, kwargs: Dict[str, Any]) -> List[str]:
+        """Convert keyword arguments to command-line arguments.
+
+        This is the inverse of _parse_extra_options in service.py.
+        Converts Python-style kwargs to command-line flags:
+
+        - Boolean True: flag without value (e.g., {'cost': True} → '--cost')
+        - False/None: skip the flag
+        - Other values: flag with value (e.g., {'depth': 3} → '--depth 3')
+
+        Args:
+            kwargs: Dictionary of keyword arguments
+
+        Returns:
+            List of command-line argument strings
+
+        Examples:
+            {'cost': True} → ['--cost']
+            {'depth': 3} → ['--depth', '3']
+            {'no_total': True} → ['--no-total']
+            {'_tty_out': False} → []  (underscore prefix = internal, skip)
+        """
+        args = []
+
+        for key, value in kwargs.items():
+            # Skip internal parameters (start with underscore)
+            if key.startswith("_"):
+                continue
+
+            # Skip False and None values
+            if value is False or value is None:
+                continue
+
+            # Convert underscores to dashes
+            flag = key.replace("_", "-")
+
+            # Add flag
+            if flag.startswith("-"):
+                args.append(flag)
+            else:
+                args.append(f"--{flag}")
+
+            # Add value if it's not a boolean flag
+            if value is not True:
+                args.append(str(value))
+
+        return args
+
+    def run(
+        self,
+        command: Union[str, List[str]],
+        *args: str,
+        capture_output: bool = True,
+        text: bool = True,
+        check: bool = True,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess:
+        """Run a command and return the result.
+
+        Args:
+            command: Command to run (string or list)
+            *args: Additional positional arguments
+            capture_output: Whether to capture stdout/stderr
+            text: Whether to return text (str) instead of bytes
+            check: If True, raise CommandError on non-zero exit
+            **kwargs: Additional keyword arguments (converted to flags)
+
+        Returns:
+            CompletedProcess with stdout, stderr, returncode
+
+        Raises:
+            CommandError: If command fails and check=True
+        """
+        # Build command list
+        if isinstance(command, str):
+            cmd_list = [command]
+        else:
+            cmd_list = list(command)
+
+        # Add positional arguments
+        cmd_list.extend(args)
+
+        # Add keyword arguments as flags
+        cmd_list.extend(self._kwargs_to_args(kwargs))
+
+        # Prepare environment
+        process_env = None
+        if self.env:
+            import os
+
+            process_env = {**os.environ, **self.env}
+
+        # Run command
+        try:
+            result = subprocess.run(
+                cmd_list,
+                capture_output=capture_output,
+                text=text,
+                check=False,  # We'll check manually for better error messages
+                env=process_env,
+            )
+        except FileNotFoundError as e:
+            raise CommandError(
+                cmd_list,
+                -1,
+                f"Command not found: {cmd_list[0]}",
+            ) from e
+
+        # Check result
+        if check and result.returncode != 0:
+            raise CommandError(
+                cmd_list,
+                result.returncode,
+                result.stderr if capture_output else None,
+            )
+
+        return result
+
+    def __call__(
+        self,
+        command: Union[str, List[str]],
+        *args: str,
+        **kwargs: Any,
+    ) -> str:
+        """Convenient method to run command and get stdout as string.
+
+        Args:
+            command: Command to run
+            *args: Positional arguments
+            **kwargs: Keyword arguments (converted to flags)
+
+        Returns:
+            stdout as string
+
+        Raises:
+            CommandError: If command fails
+        """
+        result = self.run(command, *args, capture_output=True, text=True, **kwargs)
+        return result.stdout
+
+
+class HLedgerCommand:
+    """HLedger command wrapper with sh-like API."""
+
+    def __init__(self, executor: SubprocessExecutor):
+        self.executor = executor
+        self._command = "hledger"
+
+    def __getattr__(self, name: str) -> "HLedgerSubCommand":
+        """Create a subcommand (e.g., hledger.balance).
+
+        Args:
+            name: Subcommand name (e.g., 'balance', 'register')
+
+        Returns:
+            HLedgerSubCommand that can be called
+        """
+        return HLedgerSubCommand(self._command, name, self.executor)
+
+
+class HLedgerSubCommand:
+    """HLedger subcommand (e.g., hledger balance).
+
+    Provides a callable interface similar to sh.hledger.balance().
+    """
+
+    def __init__(
+        self,
+        parent_command: str,
+        subcommand: str,
+        executor: SubprocessExecutor,
+    ):
+        self.parent = parent_command
+        self.name = subcommand
+        self.executor = executor
+
+    def __call__(
+        self,
+        queries: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        """Execute the hledger subcommand.
+
+        Args:
+            queries: Optional list of query strings
+            **kwargs: Additional command-line flags
+
+        Returns:
+            Command stdout as string
+
+        Raises:
+            CommandError: If command fails
+        """
+        # Build command: hledger <subcommand> [query...]
+        cmd = [self.parent, self.name]
+
+        # Add queries if provided
+        if queries:
+            cmd.extend(queries)
+
+        # Execute and return stdout
+        return self.executor.run(cmd, **kwargs).stdout

--- a/src/hledger_tui/core/subprocess_executor.py
+++ b/src/hledger_tui/core/subprocess_executor.py
@@ -180,16 +180,19 @@ class SubprocessExecutor:
     def _escape_ps_arg(arg: str) -> str:
         """Escape argument for PowerShell.
 
+        Uses single quotes for proper escaping. All characters are literal
+        within single quotes, except single quotes which are escaped by
+        doubling (''). This handles special characters like $, `, @, &, etc.
+
         Args:
             arg: Argument to escape
 
         Returns:
             Escaped argument string
         """
-        if '"' in arg or " " in arg:
-            escaped = arg.replace('"', '\\"')
-            return f'"{escaped}"'
-        return arg
+        # Single quotes make everything literal, except single quotes themselves
+        # which are escaped by doubling ('')
+        return "'" + arg.replace("'", "''") + "'"
 
     def __call__(
         self,

--- a/src/hledger_tui/core/subprocess_executor.py
+++ b/src/hledger_tui/core/subprocess_executor.py
@@ -148,10 +148,14 @@ class SubprocessExecutor:
 
         # Run command
         try:
+            # On Windows with hledger, use UTF-8 encoding explicitly
+            encoding = "utf-8" if sys.platform == "win32" and "hledger" in str(cmd_list) else None
+
             result = subprocess.run(
                 cmd_list,
                 capture_output=capture_output,
                 text=text,
+                encoding=encoding,
                 check=False,  # We'll check manually for better error messages
                 env=process_env,
             )

--- a/src/hledger_tui/core/subprocess_executor.py
+++ b/src/hledger_tui/core/subprocess_executor.py
@@ -5,7 +5,6 @@ Provides a sh-like API using subprocess module for Windows compatibility.
 
 import subprocess
 import sys
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 
@@ -35,7 +34,19 @@ class SubprocessExecutor:
         Args:
             env: Optional environment variables to pass to subprocess
         """
+        import os
+
         self.env = env or {}
+        # Set UTF-8 encoding for hledger by default
+        if "HLEDGER_ENCODING" not in os.environ:
+            self.env["HLEDGER_ENCODING"] = "UTF-8"
+        # Set locale for Windows
+        if sys.platform == "win32":
+            self.env["PYTHONIOENCODING"] = "utf-8"
+            if "LC_ALL" not in os.environ:
+                self.env["LC_ALL"] = "C.UTF-8"
+            if "LANG" not in os.environ:
+                self.env["LANG"] = "C.UTF-8"
 
     def _kwargs_to_args(self, kwargs: Dict[str, Any]) -> List[str]:
         """Convert keyword arguments to command-line arguments.
@@ -129,6 +140,12 @@ class SubprocessExecutor:
 
             process_env = {**os.environ, **self.env}
 
+        # On Windows, wrap command to set UTF-8 code page for hledger
+        if sys.platform == "win32" and cmd_list and "hledger" in cmd_list[0].lower():
+            # Use PowerShell to set UTF-8 code page before running command
+            ps_command = f"[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; chcp 65001 | Out-Null; & {' '.join(map(self._escape_ps_arg, cmd_list))}"
+            cmd_list = ["powershell", "-NoProfile", "-Command", ps_command]
+
         # Run command
         try:
             result = subprocess.run(
@@ -154,6 +171,20 @@ class SubprocessExecutor:
             )
 
         return result
+
+    @staticmethod
+    def _escape_ps_arg(arg: str) -> str:
+        """Escape argument for PowerShell.
+
+        Args:
+            arg: Argument to escape
+
+        Returns:
+            Escaped argument string
+        """
+        if '"' in arg or " " in arg:
+            return f'"{arg.replace('"', '\\"')}"'
+        return arg
 
     def __call__(
         self,

--- a/src/hledger_tui/ui/widgets/hledger_statistics.py
+++ b/src/hledger_tui/ui/widgets/hledger_statistics.py
@@ -8,6 +8,8 @@ from textual.widget import Widget
 from textual.widgets import Static
 from typing_extensions import override
 
+from hledger_tui.core.subprocess_executor import SubprocessExecutor
+
 
 class HLedgerStatistics(Widget):
     DEFAULT_CSS = """
@@ -40,6 +42,7 @@ class HLedgerStatistics(Widget):
             id=id,
             classes=classes,
         )
+        self.executor = SubprocessExecutor()
 
     @override
     def compose(self) -> ComposeResult:
@@ -194,7 +197,6 @@ class HLedgerStatistics(Widget):
             days: If specified, only count transactions from the last N days.
         """
         try:
-            import subprocess
             from datetime import datetime, timedelta
 
             # Get all transactions with their status
@@ -206,10 +208,8 @@ class HLedgerStatistics(Widget):
                 start_date = end_date - timedelta(days=days)
                 cmd.extend(["--begin", start_date.strftime("%Y-%m-%d")])
 
-            result = subprocess.run(
+            result = self.executor.run(
                 cmd,
-                capture_output=True,
-                text=True,
                 check=False,
             )
 

--- a/src/hledger_tui/ui/widgets/hledger_statistics.py
+++ b/src/hledger_tui/ui/widgets/hledger_statistics.py
@@ -194,8 +194,8 @@ class HLedgerStatistics(Widget):
             days: If specified, only count transactions from the last N days.
         """
         try:
-            from datetime import datetime, timedelta
             import subprocess
+            from datetime import datetime, timedelta
 
             # Get all transactions with their status
             # Unmarked transactions don't have ! or * status

--- a/src/hledger_tui/ui/widgets/hledger_statistics.py
+++ b/src/hledger_tui/ui/widgets/hledger_statistics.py
@@ -195,19 +195,28 @@ class HLedgerStatistics(Widget):
         """
         try:
             from datetime import datetime, timedelta
-
-            import sh
+            import subprocess
 
             # Get all transactions with their status
             # Unmarked transactions don't have ! or * status
-            args = []
+            cmd = ["hledger", "print"]
             if days is not None:
                 # Calculate the date range
                 end_date = datetime.now()
                 start_date = end_date - timedelta(days=days)
-                args.extend(["--begin", start_date.strftime("%Y-%m-%d")])
+                cmd.extend(["--begin", start_date.strftime("%Y-%m-%d")])
 
-            output = sh.hledger.print(*args, _tty_out=False)  # pyright: ignore
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            if result.returncode != 0:
+                return None
+
+            output = result.stdout
             lines = output.split("\n")
 
             unmarked = 0

--- a/tests/test_subprocess_executor.py
+++ b/tests/test_subprocess_executor.py
@@ -1,11 +1,11 @@
 """Tests for subprocess executor."""
 
-import subprocess
 import os
+
 from hledger_tui.core.subprocess_executor import (
-    SubprocessExecutor,
-    HLedgerCommand,
     CommandError,
+    HLedgerCommand,
+    SubprocessExecutor,
 )
 
 
@@ -29,7 +29,7 @@ def test_command_error_on_failure():
     executor = SubprocessExecutor()
     try:
         # This command should fail on most systems
-        if os.name == 'nt':
+        if os.name == "nt":
             executor.run("cmd", "/c", "exit", "1", check=True)
         else:
             executor.run("false", check=True)

--- a/tests/test_subprocess_executor.py
+++ b/tests/test_subprocess_executor.py
@@ -1,0 +1,104 @@
+"""Tests for subprocess executor."""
+
+import subprocess
+import os
+from hledger_tui.core.subprocess_executor import (
+    SubprocessExecutor,
+    HLedgerCommand,
+    CommandError,
+)
+
+
+def test_executor_runs_simple_command():
+    """Test that executor can run a simple command."""
+    executor = SubprocessExecutor()
+    result = executor.run("echo", "hello")
+    assert result.stdout.strip() == "hello"
+
+
+def test_executor_with_kwargs():
+    """Test that executor converts kwargs to command-line flags."""
+    executor = SubprocessExecutor()
+    # Python command with --version flag
+    result = executor.run("python", version=True, check=False)
+    assert "Python" in result.stdout or result.returncode != 0
+
+
+def test_command_error_on_failure():
+    """Test that CommandError is raised for failed commands."""
+    executor = SubprocessExecutor()
+    try:
+        # This command should fail on most systems
+        if os.name == 'nt':
+            executor.run("cmd", "/c", "exit", "1", check=True)
+        else:
+            executor.run("false", check=True)
+        assert False, "Should have raised CommandError"
+    except CommandError as e:
+        assert e.returncode != 0
+
+
+def test_hledger_command_wrapper():
+    """Test HLedgerCommand wrapper (if hledger is installed)."""
+    executor = SubprocessExecutor()
+    hledger = HLedgerCommand(executor)
+
+    try:
+        version = hledger.version()
+        # If we get here, hledger is installed
+        assert "hledger" in version.lower() or "version" in version.lower()
+    except CommandError:
+        # hledger not installed, skip test
+        pass
+
+
+def test_kwargs_to_args_conversion():
+    """Test _kwargs_to_args conversion logic."""
+    executor = SubprocessExecutor()
+
+    # Boolean flag
+    args = executor._kwargs_to_args({"verbose": True})
+    assert args == ["--verbose"]
+
+    # Flag with value
+    args = executor._kwargs_to_args({"depth": 3})
+    assert args == ["--depth", "3"]
+
+    # Underscore to dash
+    args = executor._kwargs_to_args({"no_total": True})
+    assert args == ["--no-total"]
+
+    # Internal param (skip)
+    args = executor._kwargs_to_args({"_tty_out": False})
+    assert args == []
+
+    # False value (skip)
+    args = executor._kwargs_to_args({"verbose": False})
+    assert args == []
+
+    # None value (skip)
+    args = executor._kwargs_to_args({"verbose": None})
+    assert args == []
+
+    # Mixed case
+    args = executor._kwargs_to_args({"verbose": True, "depth": 2, "_tty_out": False})
+    assert args == ["--verbose", "--depth", "2"]
+
+
+def test_executor_callable_interface():
+    """Test the __call__ method returns stdout as string."""
+    executor = SubprocessExecutor()
+    output = executor("echo", "test")
+    assert output.strip() == "test"
+
+
+def test_command_error_with_stderr():
+    """Test that CommandError includes stderr when available."""
+    executor = SubprocessExecutor()
+    try:
+        # Try to run a non-existent command
+        executor.run("nonexistent_command_xyz123", check=True)
+        assert False, "Should have raised CommandError"
+    except CommandError as e:
+        assert "nonexistent_command_xyz123" in str(e)
+        assert e.returncode == -1  # FileNotFoundError return code

--- a/uv.lock
+++ b/uv.lock
@@ -563,7 +563,6 @@ version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "dataconfy" },
-    { name = "sh" },
     { name = "textual" },
     { name = "textual-dev" },
     { name = "textual-plotext" },
@@ -586,7 +585,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "dataconfy" },
-    { name = "sh" },
     { name = "textual" },
     { name = "textual-dev" },
     { name = "textual-plotext" },
@@ -1574,15 +1572,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
     { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
     { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
-]
-
-[[package]]
-name = "sh"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/59/52/f43920223c93e31874677c681b8603d36a40d3d8502d3a37f80d3995d43e/sh-2.2.2.tar.gz", hash = "sha256:653227a7c41a284ec5302173fbc044ee817c7bad5e6e4d8d55741b9aeb9eb65b", size = 345866, upload-time = "2025-02-24T07:16:25.363Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/98/d82f14ac7ffedbd38dfa2383f142b26d18d23ca6cf35a40f4af60df666bd/sh-2.2.2-py3-none-any.whl", hash = "sha256:e0b15b4ae8ffcd399bc8ffddcbd770a43c7a70a24b16773fbb34c001ad5d52af", size = 38295, upload-time = "2025-02-24T07:16:23.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Note: AI usage
Relied heavily on claude code.

## Summary

  Replaces the Python `sh` library with the standard library `subprocess` module to enable cross-platform compatibility, particularly for Windows environments where the `sh` library has limited support.

  ## Changes

  **Core refactoring:**
  - Created `SubprocessExecutor` module with sh-like API wrapper
  - Updated `ShellHLedgerBackend` to use subprocess instead of sh
  - Replaced `sh.hledger.print()` in `hledger_statistics.py` with subprocess calls
  - Removed `sh` dependency from `pyproject.toml`

  **Windows-specific fixes:**
  - Added UTF-8 code page 65001 support via PowerShell wrapper for hledger commands
  - Explicit UTF-8 encoding for Windows subprocess calls
  - Fixed `justfile` venv command for Windows (Scripts/activate vs bin/activate)

  **Python 3.10 compatibility:**
  - Fixed f-string escape sequence syntax (Python 3.12+ feature)

  **Testing:**
  - Added comprehensive test suite for subprocess executor (104 lines)
  - All 125 tests passing

  ## Files changed

  - `justfile` - Fix venv activation for Windows
  - `pyproject.toml` - Remove sh dependency
  - `src/hledger_tui/core/service.py` - Update to use SubprocessExecutor
  - `src/hledger_tui/core/subprocess_executor.py` - New cross-platform executor
  - `src/hledger_tui/ui/widgets/hledger_statistics.py` - Replace sh.hledger.print()
  - `tests/test_subprocess_executor.py` - New test coverage

  ## Test coverage

  - Overall: 78%
  - All 125 tests passing
  - Quality checks passing (ruff, pytest)

  ## Breaking changes

  None. API remains compatible with existing code.

  ## Test Plan

  - [x] All 125 existing tests passing
  - [x] New subprocess executor tests added and passing
  - [x] Code quality checks passing (ruff format, ruff check)
  - [x] Manual testing on Windows with actual hledger journal file
  - [ ] Manual testing on Linux/macOS to verify no regression (I have no linux/mac, so cannot perform)